### PR TITLE
Initialize Snap-n-Split monorepo scaffold

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+# OpenAI
+OPENAI_API_KEY=
+
+# Supabase
+SUPABASE_URL=
+SUPABASE_ANON_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+node_modules
+.DS_Store
+.env
+.env.*
+!.env.sample
+*.log
+
+# Expo
+.expo
+.expo-shared
+
+# build output
+/dist
+/build
+.next
+
+# misc
+**/coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Main
+# Snap-n-Split
+
+Cross platform receipt parsing and bill splitting application.
+
+## Monorepo Layout
+
+- `apps/mobile` – Expo React Native app for iOS, Android and Web.
+- `apps/web` – Web entry (shares code with mobile via Expo).
+- `packages/ui` – Reusable UI components.
+- `packages/receipt-parser` – OpenAI GPT-4o helper for extracting receipt data.
+- `server` – Edge functions and Supabase helpers.
+- `docs` – Architecture and security docs.
+
+## Setup
+
+1. Install `pnpm`.
+2. Copy `.env.sample` to `.env` and fill values.
+3. Run `pnpm install`.
+4. Start development with `pnpm dev`.
+
+## Contributing
+
+Use conventional commits.
+Run `pnpm lint && pnpm test` before submitting a PR.
+
+

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "Snap-n-Split",
+    "slug": "snap-n-split",
+    "plugins": ["expo-router"],
+    "platforms": ["ios", "android", "web"],
+    "version": "1.0.0"
+  }
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,6 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+
+export default function Layout() {
+  return <Stack />;
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Screen } from 'ui';
+
+export default function Home() {
+  return <Screen title="Snap-n-Split">Welcome</Screen>;
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "dev": "expo start",
+    "build": "expo export:web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "expo-router": "^2.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "zustand": "^4.3.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snap-n-Split</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Screen } from 'ui';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Screen title="Snap-n-Split Web">Welcome</Screen>
+  </React.StrictMode>,
+);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,18 @@
+```mermaid
+graph TD
+  user((User))
+  mobile(Mobile App)
+  web(Web App)
+  server(Edge Functions)
+  supabase[(Supabase)]
+  openai((OpenAI GPT-4o))
+
+  user --> mobile
+  user --> web
+  mobile -- realtime / auth --> supabase
+  web -- realtime / auth --> supabase
+  mobile -- parse request --> server
+  server -- store / realtime --> supabase
+  server -- AI call --> openai
+  supabase <--> server
+```

--- a/docs/erd.mmd
+++ b/docs/erd.mmd
@@ -1,0 +1,39 @@
+```mermaid
+classDiagram
+  class users {
+    id uuid PK
+    email text
+    display_name text
+    avatar_url text
+    created_at timestamptz
+  }
+  class receipts {
+    id uuid PK
+    owner_id uuid FK -> users.id
+    image_url text
+    parsed_json jsonb
+    created_at timestamptz
+  }
+  class bill_shares {
+    id uuid PK
+    receipt_id uuid FK -> receipts.id
+    inviter_id uuid FK -> users.id
+    invitee_email text
+    role text
+    status text
+  }
+  class line_items {
+    id uuid PK
+    receipt_id uuid FK -> receipts.id
+    name text
+    qty int
+    unit_price numeric
+    total_price numeric
+  }
+  class item_assignments {
+    id uuid PK
+    line_item_id uuid FK -> line_items.id
+    user_id uuid FK -> users.id
+    share numeric
+  }
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,7 @@
+# Security Checklist
+
+- [ ] All secrets stored in environment variables and Supabase Secrets.
+- [ ] HTTPS enforced across all endpoints.
+- [ ] Access control rules applied to Supabase tables.
+- [ ] Images encrypted at rest with signed URLs for access.
+- [ ] GDPR delete implemented via edge function.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "private": true,
+  "name": "snap-n-split",
+  "packageManager": "pnpm@8.6.0",
+  "scripts": {
+    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "format": "prettier --write .",
+    "typecheck": "tsc -b",
+    "test": "turbo test",
+    "dev": "turbo run dev",
+    "build": "turbo run build"
+  },
+  "workspaces": [
+    "apps/mobile",
+    "apps/web",
+    "packages/*",
+    "server"
+  ],
+  "devDependencies": {
+    "eslint": "^8.59.0",
+    "prettier": "^3.0.3",
+    "turbo": "^1.10.2",
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/receipt-parser/package.json
+++ b/packages/receipt-parser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "receipt-parser",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/receipt-parser/src/index.ts
+++ b/packages/receipt-parser/src/index.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export const LineItemSchema = z.object({
+  name: z.string(),
+  qty: z.number(),
+  unit_price: z.number(),
+  total_price: z.number(),
+});
+
+export const ParsedReceiptSchema = z.object({
+  merchant: z.string().nullable(),
+  datetime_iso: z.string().nullable(),
+  currency: z.string().nullable(),
+  subtotal: z.number().nullable(),
+  tax: z.number().nullable(),
+  tip: z.number().nullable(),
+  total: z.number().nullable(),
+  line_items: z.array(LineItemSchema).nullable(),
+});
+
+export type ParsedReceipt = z.infer<typeof ParsedReceiptSchema>;
+
+/**
+ * Send a receipt image to GPT-4o and return structured JSON.
+ */
+export async function parseReceipt(base64Image: string, apiKey: string): Promise<ParsedReceipt> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini-vision',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a world-class data extractor. Return ONLY valid JSON that conforms to the TypeScript interface.',
+        },
+        { role: 'user', content: [{ type: 'image_url', image_url: `data:image/jpeg;base64,${base64Image}` }] },
+      ],
+    }),
+  });
+
+  const text = await response.text();
+  const json = JSON.parse(text);
+  return ParsedReceiptSchema.parse(json);
+}

--- a/packages/receipt-parser/tsconfig.json
+++ b/packages/receipt-parser/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -1,0 +1,11 @@
+import { View, Text } from 'react-native';
+import React from 'react';
+
+type Props = { title: string };
+
+export const Screen: React.FC<Props> = ({ title, children }) => (
+  <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <Text accessibilityRole="header">{title}</Text>
+    {children}
+  </View>
+);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ui",
+  "version": "0.1.0",
+  "main": "index.tsx"
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js';
+import { parseReceipt } from 'receipt-parser';
+import 'dotenv/config';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseKey = process.env.SUPABASE_ANON_KEY as string;
+const openAiKey = process.env.OPENAI_API_KEY as string;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export async function handleImage(base64: string, userId: string) {
+  const parsed = await parseReceipt(base64, openAiKey);
+  const { data } = await supabase.storage
+    .from('receipts')
+    .upload(`${userId}/${Date.now()}.jpg`, Buffer.from(base64, 'base64'), {
+      contentType: 'image/jpeg',
+    });
+
+  await supabase.from('receipts').insert({
+    owner_id: userId,
+    image_url: data?.path,
+    parsed_json: parsed,
+  });
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "server",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "scripts": {
+    "dev": "ts-node-dev index.ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.38.3",
+    "receipt-parser": "workspace:*"
+  },
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0"
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "lib": ["es2019", "dom"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "packages/**/*",
+    "apps/**/*",
+    "server/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- setup Turborepo style workspace
- scaffold Expo mobile app and Vite web app
- add reusable UI package and receipt parser helper
- create server folder with Supabase helper
- add docs with architecture and ERD diagrams

## Testing
- `npm test` *(fails: turbo not found)*